### PR TITLE
fix(core): only limit all amounts to 6 decimal places maximum

### DIFF
--- a/apps/server/src/defichain/services/WhaleWalletService.ts
+++ b/apps/server/src/defichain/services/WhaleWalletService.ts
@@ -93,7 +93,7 @@ export class WhaleWalletService {
 
       // Successful verification, proceed to sign the claim
       const fee = new BigNumber(verify.amount).multipliedBy(this.configService.getOrThrow('defichain.transferFee'));
-      const amountLessFee = BigNumber.max(verify.amount.minus(fee), 0).toFixed();
+      const amountLessFee = BigNumber.max(verify.amount.minus(fee), 0).toFixed(6, BigNumber.ROUND_FLOOR);
 
       const claim = await this.evmTransactionService.signClaim({
         receiverAddress: verify.ethReceiverAddress,

--- a/apps/web/src/components/BridgeForm.tsx
+++ b/apps/web/src/components/BridgeForm.tsx
@@ -509,7 +509,10 @@ export default function BridgeForm({
         </span>
         <NumericFormat
           className="max-w-[70%] block break-words text-right text-dark-1000 text-sm leading-5 lg:text-lg lg:leading-6 font-bold"
-          value={BigNumber(new BigNumber(amount || 0).minus(fee))}
+          value={BigNumber.max(new BigNumber(amount).minus(fee), 0).toFixed(
+            6,
+            BigNumber.ROUND_FLOOR
+          )}
           thousandSeparator
           suffix={` ${selectedTokensB.tokenA.name}`}
           trimTrailingZeros

--- a/apps/web/src/components/BridgeForm.tsx
+++ b/apps/web/src/components/BridgeForm.tsx
@@ -509,10 +509,10 @@ export default function BridgeForm({
         </span>
         <NumericFormat
           className="max-w-[70%] block break-words text-right text-dark-1000 text-sm leading-5 lg:text-lg lg:leading-6 font-bold"
-          value={BigNumber.max(new BigNumber(amount).minus(fee), 0).toFixed(
-            6,
-            BigNumber.ROUND_FLOOR
-          )}
+          value={BigNumber.max(
+            new BigNumber(amount || 0).minus(fee),
+            0
+          ).toFixed(6, BigNumber.ROUND_FLOOR)}
           thousandSeparator
           suffix={` ${selectedTokensB.tokenA.name}`}
           trimTrailingZeros

--- a/apps/web/src/components/ConfirmTransferModal.tsx
+++ b/apps/web/src/components/ConfirmTransferModal.tsx
@@ -76,7 +76,7 @@ function RowData({
               "md:text-lg md:font-semibold",
               data.amount.isPositive() ? "text-valid" : "text-error"
             )}
-            value={data.amount}
+            value={data.amount.toFixed(6, BigNumber.ROUND_FLOOR)}
             thousandSeparator
             trimTrailingZeros
           />

--- a/apps/web/src/components/erc-transfer/StepLastClaim.tsx
+++ b/apps/web/src/components/erc-transfer/StepLastClaim.tsx
@@ -70,7 +70,10 @@ export default function StepLastClaim({
 
   // Prepare write contract for `claimFund` function
   const [fee] = useTransferFee(data.to.amount.toString());
-  const amountLessFee = BigNumber.max(data.to.amount.minus(fee), 0).toFixed();
+  const amountLessFee = BigNumber.max(data.to.amount.minus(fee), 0).toFixed(
+    6,
+    BigNumber.ROUND_DOWN
+  );
   const parsedAmount = isTokenETH
     ? utils.parseEther(amountLessFee)
     : utils.parseUnits(amountLessFee, tokenDecimals);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Claim with small amount is failing for tokens with 6 decimal places (USDC, EUROC). This happens when fee is deducted from the amount and the resulting difference has more than six decimals.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
