### PR TITLE
fix(stats): fix missing WBTC stats for ethereum

### DIFF
--- a/apps/server/src/ethereum/services/EVMTransactionConfirmerService.ts
+++ b/apps/server/src/ethereum/services/EVMTransactionConfirmerService.ts
@@ -113,11 +113,14 @@ export class EVMTransactionConfirmerService {
     };
 
     for (const transaction of confirmedTransactions) {
-      const { tokenSymbol, amount } = transaction;
+      let { tokenSymbol } = transaction;
+      if (tokenSymbol === TokenSymbol.BTC) {
+        tokenSymbol = SupportedEVMTokenSymbols.WBTC;
+      }
       if (tokenSymbol && tokenSymbol in SupportedEVMTokenSymbols) {
         amountBridgedBigN[tokenSymbol as SupportedEVMTokenSymbols] = amountBridgedBigN[
           tokenSymbol as SupportedEVMTokenSymbols
-        ].plus(BigNumber(amount as string));
+        ].plus(BigNumber(transaction.amount as string));
       }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Maps `BTC` token symbol from database (`BridgeEventTransactions`) to `WBTC` to get daily stats of bridged for WBTC token.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
For verification, [https://api.quantumbridge.app/ethereum/stats?date=2023-03-17](https://api.quantumbridge.app/ethereum/stats?date=2023-03-17) should not be 0 WBTC

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
